### PR TITLE
Fix integer overflow in MicrosecondTime()

### DIFF
--- a/fixes/fixes.cpp
+++ b/fixes/fixes.cpp
@@ -58,7 +58,7 @@
 			ts;
 		clock_gettime(CLOCK_MONOTONIC, &ts);
 		//return ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
-		return ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
+		return ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000;
 	}
 #else
 	#define VC_EXTRALEAN


### PR DESCRIPTION
This fixes a bug on Linux where repeating timers would start running indefinitely without a delay. I've already posted this patch in the fixes2 topic but it seems that Y_Less haven't uploaded a new version ever since.